### PR TITLE
Refactor PID gains to tuple-based API

### DIFF
--- a/main.py
+++ b/main.py
@@ -146,29 +146,12 @@ def load_pid_gains(parameters) -> dict:
         dict: PID gains for position, altitude, attitude, horizontal speed, and vertical speed.
     """
     return {
-        'kp_pos': float(parameters['kp_pos']),
-        'ki_pos': float(parameters['ki_pos']),
-        'kd_pos': float(parameters['kd_pos']),
-
-        'kp_alt': float(parameters['kp_alt']),
-        'ki_alt': float(parameters['ki_alt']),
-        'kd_alt': float(parameters['kd_alt']),
-
-        'kp_att': float(parameters['kp_att']),
-        'ki_att': float(parameters['ki_att']),
-        'kd_att': float(parameters['kd_att']),
-
-        'kp_yaw': float(parameters['kp_yaw']),
-        'ki_yaw': float(parameters['ki_yaw']),
-        'kd_yaw': float(parameters['kd_yaw']),
-
-        'kp_hsp': float(parameters['kp_hsp']),
-        'ki_hsp': float(parameters['ki_hsp']),
-        'kd_hsp': float(parameters['kd_hsp']),
-
-        'kp_vsp': float(parameters['kp_vsp']),
-        'ki_vsp': float(parameters['ki_vsp']),
-        'kd_vsp': float(parameters['kd_vsp'])
+        'k_pid_pos': tuple(map(float, parameters['k_pid_pos'])),
+        'k_pid_alt': tuple(map(float, parameters['k_pid_alt'])),
+        'k_pid_att': tuple(map(float, parameters['k_pid_att'])),
+        'k_pid_yaw': tuple(map(float, parameters['k_pid_yaw'])),
+        'k_pid_hsp': tuple(map(float, parameters['k_pid_hsp'])),
+        'k_pid_vsp': tuple(map(float, parameters['k_pid_vsp'])),
     }
 
 def create_quadcopter_controller(init_state, pid_gains, t_max, parameters) -> QuadCopterController:

--- a/parameters.yaml
+++ b/parameters.yaml
@@ -21,24 +21,12 @@ norm_params_path: "Rotor/normalization_params.pth"
 rotor_model_path: "Rotor/rotor_model.pth"
 
 # PID controller settings (yaw remain fixed)
-kp_pos: 0.7605314210227943
-ki_pos: 0.37624518297791576
-kd_pos: 1.0
-kp_alt: 196.60373623182426
-ki_alt: 29.090249051600722
-kd_alt: 107.90640578767405
-kp_att: 2.3755182014455283
-ki_att: 1e-05
-kd_att: 2.808073996317681
-kp_yaw: 0.5
-ki_yaw: 1e-06
-kd_yaw: 0.1
-kp_hsp: 124.37310350657175
-ki_hsp: 1e-05
-kd_hsp: 0.7454357201860323
-kp_vsp: 114.68965027417173
-ki_vsp: 1.0
-kd_vsp: 0.6251197244454744
+k_pid_pos: [0.7605314210227943, 0.37624518297791576, 1.0]
+k_pid_alt: [196.60373623182426, 29.090249051600722, 107.90640578767405]
+k_pid_att: [2.3755182014455283, 1e-05, 2.808073996317681]
+k_pid_yaw: [0.5, 1e-06, 0.1]
+k_pid_hsp: [124.37310350657175, 1e-05, 0.7454357201860323]
+k_pid_vsp: [114.68965027417173, 1.0, 0.6251197244454744]
 
 
 # Drone parameters

--- a/pid_optimization_PSO.py
+++ b/pid_optimization_PSO.py
@@ -42,7 +42,8 @@ def log_step(params: dict, cost: float) -> None:
     current = time()
     entry = {
         'target': -cost,
-        'params': {k: float(v) for k, v in params.items()},
+        'params': {k: ([float(x) for x in v] if isinstance(v, (list, tuple)) else float(v))
+                   for k, v in params.items()},
         'datetime': {
             'datetime': datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
             'elapsed': current - start_time,
@@ -110,9 +111,15 @@ def pso_optimize(pbounds: dict) -> None:
     velocities = np.zeros_like(positions)
 
     def vector_to_dict(vec):
-        d = {name: float(value) for name, value in zip(names, vec)}
-        d.update({'kp_yaw': 0.5, 'ki_yaw': 1e-6, 'kd_yaw': 0.1})
-        return d
+        vals = {name: float(value) for name, value in zip(names, vec)}
+        return {
+            'k_pid_pos': (vals['kp_pos'], vals['ki_pos'], vals['kd_pos']),
+            'k_pid_alt': (vals['kp_alt'], vals['ki_alt'], vals['kd_alt']),
+            'k_pid_att': (vals['kp_att'], vals['ki_att'], vals['kd_att']),
+            'k_pid_yaw': (0.5, 1e-6, 0.1),
+            'k_pid_hsp': (vals['kp_hsp'], vals['ki_hsp'], vals['kd_hsp']),
+            'k_pid_vsp': (vals['kp_vsp'], vals['ki_vsp'], vals['kd_vsp']),
+        }
 
     personal_best = positions.copy()
     personal_best_cost = np.full(num_particles, np.inf)

--- a/pid_optimization_sac.py
+++ b/pid_optimization_sac.py
@@ -88,12 +88,12 @@ class PIDGainEnv(gym.Env):
 
     def step(self, action: np.ndarray):  # type: ignore[override]
         gains = {
-            'kp_pos': float(action[0]), 'ki_pos': float(action[1]), 'kd_pos': float(action[2]),
-            'kp_alt': float(action[3]), 'ki_alt': float(action[4]), 'kd_alt': float(action[5]),
-            'kp_att': float(action[6]), 'ki_att': float(action[7]), 'kd_att': float(action[8]),
-            'kp_yaw': 0.5, 'ki_yaw': 1e-6, 'kd_yaw': 0.1,
-            'kp_hsp': float(action[9]), 'ki_hsp': float(action[10]), 'kd_hsp': float(action[11]),
-            'kp_vsp': float(action[9]), 'ki_vsp': float(action[10]), 'kd_vsp': float(action[11]),
+            'k_pid_pos': (float(action[0]), float(action[1]), float(action[2])),
+            'k_pid_alt': (float(action[3]), float(action[4]), float(action[5])),
+            'k_pid_att': (float(action[6]), float(action[7]), float(action[8])),
+            'k_pid_yaw': (0.5, 1e-6, 0.1),
+            'k_pid_hsp': (float(action[9]), float(action[10]), float(action[11])),
+            'k_pid_vsp': (float(action[9]), float(action[10]), float(action[11])),
         }
         cost, final_time, final_distance, pitch_osc, roll_osc, thrust_osc, reached = simulate_pid(gains)
         reward = -cost


### PR DESCRIPTION
## Summary
- accept PID gain tuples in `PIDController`
- store gain tuples in `parameters.yaml`
- adjust `load_pid_gains` and controller init to use tuples
- update optimization scripts and RL env for new gain format

## Testing
- `python -m py_compile Controller.py main.py pid_optimization_bayopt.py pid_optimization_PSO.py pid_optimization_sac.py`

------
https://chatgpt.com/codex/tasks/task_e_6887206344e4832bb45ed683ef343e5b