### PR TITLE
Refactor PID optimizers into classes

### DIFF
--- a/pid_optimization_RL.py
+++ b/pid_optimization_RL.py
@@ -1,29 +1,16 @@
 # Author: Andrea Vaiuso
-# Version: 1.0
+# Version: 1.1
 # Date: 31.07.2025
-# Description: This module implements a TD3-based Reinforcement Learning approach
-#              for PID gain tuning of a drone controller. The implementation is
-#              inspired by the methodology presented in "Processes 2025, 13, 735"
-#              and follows the structure of the existing optimization scripts.
-
-"""TD3 optimization for PID tuning.
-
-This script trains a TD3 agent to propose new sets of PID gains for the
-drone controller. Each action of the agent corresponds to a complete PID
-configuration (with yaw PIDs fixed), while the environment returns the
-negative of the simulation cost as reward. The goal is to minimize the cost
-metrics defined in :mod:`opt_func`.
-
-Logs, results and plots are stored using the same format as in the other
-optimization scripts.
-"""
+# Description: Class-based implementation of a TD3-driven PID optimization
+#              routine for a quadcopter controller.
+"""TD3 optimization for PID tuning packaged into a class."""
 
 from __future__ import annotations
 
 import os
 from datetime import datetime
 from time import time
-from typing import Dict
+from typing import Dict, Optional
 
 import yaml
 import numpy as np
@@ -34,222 +21,235 @@ from stable_baselines3.common.noise import NormalActionNoise
 
 from World import World
 import main as mainfunc
-from Simulation import Simulation
-
 import opt_func
 from opt_func import (
     log_step,
-    calculate_costs,
-    seconds_to_hhmmss,
     plot_costs_trend,
-    show_best_params
+    show_best_params,
+    run_simulation,
 )
 
 
-# ---------------------------------------------------------------------------
-# Configuration and global objects
-# ---------------------------------------------------------------------------
+class TD3PIDOptimizer:
+    """Optimize PID gains using a Twin-Delayed DDPG agent.
 
-with open(os.path.join("Settings", "td3_opt.yaml"), "r") as f:
-    td3_cfg = yaml.safe_load(f)
-
-simulation_time = float(td3_cfg.get("simulation_time", 150))
-total_timesteps = int(td3_cfg.get("total_timesteps", 1000))
-action_noise_sigma = float(td3_cfg.get("action_noise_sigma", 0.1))
-
-timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-base_dir = os.path.join("Optimizations", "TD3", timestamp)
-os.makedirs(base_dir, exist_ok=True)
-
-opt_output_path = os.path.join(base_dir, "best_parameters.txt")
-log_path = os.path.join(base_dir, "optimization_log.json")
-
-# initialize logging timers in opt_func
-opt_func.start_time = time()
-opt_func.last_time = opt_func.start_time
-
-parameters = mainfunc.load_parameters("Settings/simulation_parameters.yaml")
-thrust_max = mainfunc.get_max_thrust_from_rotor_model(parameters)
-waypoints = mainfunc.create_training_waypoints()
-world = World.load_world(parameters["world_data_path"])
-noise_model = mainfunc.load_dnn_noise_model(parameters)
-
-pbounds_cfg = td3_cfg.get("pbounds", {})
-PB_NAMES = list(pbounds_cfg.keys())
-PB_LOW = np.array([pbounds_cfg[k][0] for k in PB_NAMES], dtype=np.float32)
-PB_HIGH = np.array([pbounds_cfg[k][1] for k in PB_NAMES], dtype=np.float32)
-DIM = len(PB_NAMES)
-
-costs: list[float] = []
-best_costs: list[float] = []
-best_cost = np.inf
-best_params: Dict[str, tuple] | None = None
-
-
-# ---------------------------------------------------------------------------
-# Helper functions
-# ---------------------------------------------------------------------------
-
-def simulate_pid(pid_gains: Dict[str, tuple]) -> Dict[str, float]:
-    """Run a simulation with the given PID gains and return the cost metrics."""
-    init_state = mainfunc.create_initial_state()
-    quad_controller = mainfunc.create_quadcopter_controller(
-        init_state=init_state,
-        pid_gains=pid_gains,
-        t_max=thrust_max,
-        parameters=parameters,
-    )
-    drone = mainfunc.create_quadcopter_model(
-        init_state=init_state, quad_controller=quad_controller, parameters=parameters
-    )
-    sim = mainfunc.create_simulation(
-        drone=drone,
-        world=world,
-        waypoints=waypoints,
-        parameters=parameters,
-        noise_model=noise_model,
-        generate_sound_map=False,
-    )
-    sim.startSimulation(
-        stop_at_target=True, verbose=False, stop_sim_if_not_moving=True, use_static_target=True
-    )
-    return calculate_costs(sim, simulation_time)
-
-
-def decode_action(vec: np.ndarray) -> Dict[str, tuple]:
-    """Convert an action vector into a dictionary of PID gains."""
-    return {
-        "k_pid_pos": (vec[0], vec[1], vec[2]),
-        "k_pid_alt": (vec[3], vec[4], vec[5]),
-        "k_pid_att": (vec[6], vec[7], vec[8]),
-        "k_pid_yaw": (0.5, 1e-6, 0.1),
-        "k_pid_hsp": (vec[9], vec[10], vec[11]),
-        "k_pid_vsp": (vec[12], vec[13], vec[14]),
-    }
-
-
-# ---------------------------------------------------------------------------
-# Environment definition
-# ---------------------------------------------------------------------------
-
-
-class PIDEnv(gym.Env):
-    """Gym environment where each action is a set of PID gains.
-
-    The observation is the last action taken. Episodes last a single step
-    (bandit-like setup). The reward is the negative total cost returned by the
-    simulator. Logging and best-parameter tracking are handled internally.
+    Parameters
+    ----------
+    config_file : str, optional
+        Path to the TD3 configuration file.
+    parameters_file : str, optional
+        Path to the simulation parameters YAML file.
+    verbose : bool, optional
+        If ``True`` print step-by-step information.
+    set_initial_obs : bool, optional
+        Start each episode from the current PID gains when ``True``.
+    simulate_wind_flag : bool, optional
+        Enable the Dryden wind model during simulations.
+    waypoints : list, optional
+        List of waypoints used for training. If ``None`` a default set is
+        generated.
     """
 
-    metadata = {"render.modes": []}
+    def __init__(
+        self,
+        config_file: str = "Settings/td3_opt.yaml",
+        parameters_file: str = "Settings/simulation_parameters.yaml",
+        *,
+        verbose: bool = True,
+        set_initial_obs: bool = True,
+        simulate_wind_flag: bool = False,
+        waypoints: Optional[list] = None,
+    ) -> None:
+        with open(config_file, "r") as f:
+            td3_cfg = yaml.safe_load(f)
 
-    def __init__(self, verbose: bool = True, set_initial_obs: bool = True):
-        super().__init__()
-        self.action_space = spaces.Box(PB_LOW, PB_HIGH, dtype=np.float32)
-        self.observation_space = spaces.Box(PB_LOW, PB_HIGH, dtype=np.float32)
-        current_best = mainfunc.load_pid_gains(parameters)
-        self.initial_obs = np.array(
-            [
-                current_best["k_pid_pos"][0],
-                current_best["k_pid_pos"][1],
-                current_best["k_pid_pos"][2],
-                current_best["k_pid_alt"][0],
-                current_best["k_pid_alt"][1],
-                current_best["k_pid_alt"][2],
-                current_best["k_pid_att"][0],
-                current_best["k_pid_att"][1],
-                current_best["k_pid_att"][2],
-                current_best["k_pid_hsp"][0],
-                current_best["k_pid_hsp"][1],
-                current_best["k_pid_hsp"][2],
-                current_best["k_pid_vsp"][0],
-                current_best["k_pid_vsp"][1],
-                current_best["k_pid_vsp"][2],
-            ],
-            dtype=np.float32,
-        )
-        self.set_initial_obs = set_initial_obs
-        if self.set_initial_obs:
-            self.state = self.initial_obs.copy()
-        else:
-            self.state = np.zeros(DIM, dtype=np.float32)
-        self.current_step = 0
+        self.simulation_time = float(td3_cfg.get("simulation_time", 150))
+        self.total_timesteps = int(td3_cfg.get("total_timesteps", 1000))
+        self.action_noise_sigma = float(td3_cfg.get("action_noise_sigma", 0.1))
+
         self.verbose = verbose
+        self.set_initial_obs = set_initial_obs
+        self.simulate_wind_flag = simulate_wind_flag
 
-    def reset(self, *, seed: int | None = None, options: dict | None = None):  # type: ignore[override]
-        super().reset(seed=seed)
-        if self.set_initial_obs:
-            self.state = self.initial_obs.copy()
-        else:
-            self.state = np.zeros(DIM, dtype=np.float32)
-        self.current_step = 0
-        return self.state, {}
+        self.timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        self.base_dir = os.path.join("Optimizations", "TD3", self.timestamp)
+        os.makedirs(self.base_dir, exist_ok=True)
+        self.opt_output_path = os.path.join(self.base_dir, "best_parameters.txt")
+        self.log_path = os.path.join(self.base_dir, "optimization_log.json")
 
-    def step(self, action: np.ndarray):  # type: ignore[override]
-        """Take a step in the environment with the given action."""
-        self.current_step += 1
-        action = np.clip(action, PB_LOW, PB_HIGH)
-        gains = decode_action(action)
-        sim_costs = simulate_pid(gains)
-        total_cost = sim_costs["total_cost"]
-        reward = -total_cost
+        # Initialize logging timers in opt_func
+        opt_func.start_time = time()
+        opt_func.last_time = opt_func.start_time
 
-        # Logging and best tracking
-        log_step(gains, total_cost, log_path, sim_costs)
-        costs.append(total_cost)
-        global best_cost, best_params
-        if total_cost < best_cost:
-            best_cost = total_cost
-            best_params = gains
-        best_costs.append(best_cost)
+        self.parameters = mainfunc.load_parameters(parameters_file)
+        self.thrust_max = mainfunc.get_max_thrust_from_rotor_model(self.parameters)
+        self.waypoints = (
+            waypoints if waypoints is not None else mainfunc.create_training_waypoints()
+        )
+        self.world = World.load_world(self.parameters["world_data_path"])
+        self.noise_model = mainfunc.load_dnn_noise_model(self.parameters)
 
-        self.state = action.astype(np.float32)
-        terminated = True  # one-step episode
-        truncated = False
-        info = {"costs": sim_costs}
-        if self.verbose: print(f"[ TD3 ] Step ({self.current_step}/{total_timesteps}) completed: total_cost={total_cost:.4f}, best_cost={best_cost:.4f}, costs: {sim_costs}")
-        return self.state, reward, terminated, truncated, info
+        pbounds_cfg = td3_cfg.get("pbounds", {})
+        self.pb_names = list(pbounds_cfg.keys())
+        self.pb_low = np.array([pbounds_cfg[k][0] for k in self.pb_names], dtype=np.float32)
+        self.pb_high = np.array([pbounds_cfg[k][1] for k in self.pb_names], dtype=np.float32)
+        self.dim = len(self.pb_names)
 
+        self.costs: list[float] = []
+        self.best_costs: list[float] = []
+        self.best_cost = np.inf
+        self.best_params: Dict[str, tuple] | None = None
+        self.step_count = 0
 
-# ---------------------------------------------------------------------------
-# Main optimization routine
-# ---------------------------------------------------------------------------
+    # ------------------------------------------------------------------
+    # Utility methods
+    # ------------------------------------------------------------------
+    def decode_action(self, vec: np.ndarray) -> Dict[str, tuple]:
+        """Convert an action vector into a dictionary of PID gains."""
+        return {
+            "k_pid_pos": (vec[0], vec[1], vec[2]),
+            "k_pid_alt": (vec[3], vec[4], vec[5]),
+            "k_pid_att": (vec[6], vec[7], vec[8]),
+            "k_pid_yaw": (0.5, 1e-6, 0.1),
+            "k_pid_hsp": (vec[9], vec[10], vec[11]),
+            "k_pid_vsp": (vec[12], vec[13], vec[14]),
+        }
+
+    def simulate_pid(self, pid_gains: Dict[str, tuple]) -> Dict[str, float]:
+        """Run a simulation with the given PID gains and return the cost metrics."""
+        return run_simulation(
+            pid_gains,
+            self.parameters,
+            self.waypoints,
+            self.world,
+            self.thrust_max,
+            self.simulation_time,
+            noise_model=self.noise_model,
+            simulate_wind=self.simulate_wind_flag,
+        )
+
+    # ------------------------------------------------------------------
+    # Environment definition
+    # ------------------------------------------------------------------
+    class PIDEnv(gym.Env):
+        """Gym environment in which each action represents a set of PID gains."""
+
+        metadata = {"render.modes": []}
+
+        def __init__(self, outer: "TD3PIDOptimizer") -> None:
+            super().__init__()
+            self.outer = outer
+            self.action_space = spaces.Box(
+                outer.pb_low, outer.pb_high, dtype=np.float32
+            )
+            self.observation_space = spaces.Box(
+                outer.pb_low, outer.pb_high, dtype=np.float32
+            )
+            current_best = mainfunc.load_pid_gains(outer.parameters)
+            self.initial_obs = np.array(
+                [
+                    current_best["k_pid_pos"][0],
+                    current_best["k_pid_pos"][1],
+                    current_best["k_pid_pos"][2],
+                    current_best["k_pid_alt"][0],
+                    current_best["k_pid_alt"][1],
+                    current_best["k_pid_alt"][2],
+                    current_best["k_pid_att"][0],
+                    current_best["k_pid_att"][1],
+                    current_best["k_pid_att"][2],
+                    current_best["k_pid_hsp"][0],
+                    current_best["k_pid_hsp"][1],
+                    current_best["k_pid_hsp"][2],
+                    current_best["k_pid_vsp"][0],
+                    current_best["k_pid_vsp"][1],
+                    current_best["k_pid_vsp"][2],
+                ],
+                dtype=np.float32,
+            )
+            if outer.set_initial_obs:
+                self.state = self.initial_obs.copy()
+            else:
+                self.state = np.zeros(outer.dim, dtype=np.float32)
+
+        def reset(self, *, seed: int | None = None, options: dict | None = None):  # type: ignore[override]
+            super().reset(seed=seed)
+            if self.outer.set_initial_obs:
+                self.state = self.initial_obs.copy()
+            else:
+                self.state = np.zeros(self.outer.dim, dtype=np.float32)
+            return self.state, {}
+
+        def step(self, action: np.ndarray):  # type: ignore[override]
+            """Take a step in the environment using the provided action."""
+            self.outer.step_count += 1
+            action = np.clip(action, self.outer.pb_low, self.outer.pb_high)
+            gains = self.outer.decode_action(action)
+            sim_costs = self.outer.simulate_pid(gains)
+            total_cost = sim_costs["total_cost"]
+            reward = -total_cost
+
+            log_step(gains, total_cost, self.outer.log_path, sim_costs)
+            self.outer.costs.append(total_cost)
+            if total_cost < self.outer.best_cost:
+                self.outer.best_cost = total_cost
+                self.outer.best_params = gains
+            self.outer.best_costs.append(self.outer.best_cost)
+
+            self.state = action.astype(np.float32)
+            terminated = True  # one-step episode
+            truncated = False
+            info = {"costs": sim_costs}
+            if self.outer.verbose:
+                print(
+                    f"[ TD3 ] Step ({self.outer.step_count}/{self.outer.total_timesteps}) "
+                    f"completed: total_cost={total_cost:.4f}, best_cost={self.outer.best_cost:.4f}, costs: {sim_costs}"
+                )
+            return self.state, reward, terminated, truncated, info
+
+    # ------------------------------------------------------------------
+    # Optimization routine
+    # ------------------------------------------------------------------
+    def optimize(self) -> None:
+        """Execute the TD3 optimization process."""
+        env = self.PIDEnv(self)
+        action_noise = NormalActionNoise(
+            mean=np.zeros(self.dim), sigma=self.action_noise_sigma * np.ones(self.dim)
+        )
+        model = TD3("MlpPolicy", env, action_noise=action_noise)
+
+        start_opt = time()
+        print("Starting TD3 optimization...")
+        try:
+            model.learn(total_timesteps=self.total_timesteps, progress_bar=False)
+        except KeyboardInterrupt:
+            print("Optimization interrupted by user.")
+        finally:
+            tot_time = time() - start_opt
+            if self.best_params is None:
+                print("No evaluations were performed.")
+                return
+            show_best_params(
+                self.best_params,
+                self.opt_output_path,
+                self.best_cost,
+                len(self.costs),
+                self.simulation_time,
+                tot_time,
+            )
+            plot_costs_trend(
+                self.costs,
+                save_path=self.opt_output_path.replace(".txt", "_costs.png"),
+            )
+            plot_costs_trend(
+                self.best_costs,
+                save_path=self.opt_output_path.replace(".txt", "_best_costs.png"),
+            )
 
 
 def main() -> None:
     """Run PID optimization using TD3."""
-
-    env = PIDEnv(verbose=True)
-
-    # Action noise for exploration
-    action_noise = NormalActionNoise(
-        mean=np.zeros(DIM), sigma=action_noise_sigma * np.ones(DIM)
-    )
-
-    model = TD3(
-        "MlpPolicy",
-        env,
-        action_noise=action_noise,
-    )
-
-    start_opt = time()
-    print("Starting TD3 optimization...")
-    try:
-        model.learn(total_timesteps=total_timesteps, progress_bar=False)
-    except KeyboardInterrupt:
-        print("Optimization interrupted by user.")
-    finally:
-        tot_time = time() - start_opt
-
-        if best_params is None:
-            print("No evaluations were performed.")
-            return
-
-        show_best_params(best_params, opt_output_path, best_cost, len(costs), simulation_time, tot_time)
-
-        # Save plots of cost trends
-        plot_costs_trend(costs, save_path=opt_output_path.replace(".txt", "_costs.png"))
-        plot_costs_trend(best_costs, save_path=opt_output_path.replace(".txt", "_best_costs.png"))
+    optimizer = TD3PIDOptimizer()
+    optimizer.optimize()
 
 
 if __name__ == "__main__":

--- a/pid_optimization_pso.py
+++ b/pid_optimization_pso.py
@@ -1,160 +1,229 @@
 # Author: Andrea Vaiuso
-# Version: 1.2
+# Version: 1.3
 # Date: 31.07.2025
-# Description: This module implements Particle Swarm Optimization (PSO) for PID gain tuning of a drone controller.
+# Description: Class-based Particle Swarm Optimization for PID gain tuning.
+"""Particle Swarm Optimization for PID tuning packaged into a class."""
 
-import json
 import os
 from datetime import datetime
 from time import time
+from typing import Dict, Optional
 
 import numpy as np
 import yaml
 
 from World import World
 import main as mainfunc
-from Simulation import Simulation
-
 import opt_func
 from opt_func import (
     log_step,
-    calculate_costs, 
-    plot_costs_trend, 
-    show_best_params
+    plot_costs_trend,
+    show_best_params,
+    run_simulation,
 )
 
-costs = []
-best_costs = []
+
+class PSOPIDOptimizer:
+    """Optimize PID gains using Particle Swarm Optimization.
+
+    Parameters
+    ----------
+    config_file : str, optional
+        Path to the PSO configuration file.
+    parameters_file : str, optional
+        Path to the simulation parameters YAML file.
+    verbose : bool, optional
+        If ``True`` print step-by-step information.
+    set_initial_obs : bool, optional
+        Include current PID gains as the first particle when ``True``.
+    simulate_wind_flag : bool, optional
+        Enable the Dryden wind model during simulations.
+    waypoints : list, optional
+        List of waypoints used for training. If ``None`` a default set is
+        generated.
+    """
+
+    def __init__(
+        self,
+        config_file: str = "Settings/pso_opt.yaml",
+        parameters_file: str = "Settings/simulation_parameters.yaml",
+        *,
+        verbose: bool = True,
+        set_initial_obs: bool = True,
+        simulate_wind_flag: bool = False,
+        waypoints: Optional[list] = None,
+    ) -> None:
+        with open(config_file, "r") as f:
+            pso_cfg = yaml.safe_load(f)
+
+        self.n_iter = int(pso_cfg.get("n_iter", 100))
+        self.swarm_size = int(pso_cfg.get("swarm_size", 30))
+        self.w = float(pso_cfg.get("inertia_weight", 0.7))
+        self.c1 = float(pso_cfg.get("cognitive_coeff", 1.5))
+        self.c2 = float(pso_cfg.get("social_coeff", 1.5))
+        self.simulation_time = float(pso_cfg.get("simulation_time", 150))
+
+        self.verbose = verbose
+        self.set_initial_obs = set_initial_obs
+        self.simulate_wind_flag = simulate_wind_flag
+
+        self.timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        self.base_dir = os.path.join("Optimizations", "PSO", self.timestamp)
+        os.makedirs(self.base_dir, exist_ok=True)
+        self.opt_output_path = os.path.join(self.base_dir, "best_parameters.txt")
+        self.log_path = os.path.join(self.base_dir, "optimization_log.json")
+
+        opt_func.start_time = time()
+        opt_func.last_time = opt_func.start_time
+
+        self.parameters = mainfunc.load_parameters(parameters_file)
+        self.thrust_max = mainfunc.get_max_thrust_from_rotor_model(self.parameters)
+        self.waypoints = (
+            waypoints if waypoints is not None else mainfunc.create_training_waypoints()
+        )
+        self.world = World.load_world(self.parameters["world_data_path"])
+        self.noise_model = mainfunc.load_dnn_noise_model(self.parameters)
+
+        pbounds_cfg = pso_cfg.get("pbounds", {})
+        self.pbounds = {k: tuple(v) for k, v in pbounds_cfg.items()}
+        self.lower_bounds = np.array([v[0] for v in self.pbounds.values()], dtype=float)
+        self.upper_bounds = np.array([v[1] for v in self.pbounds.values()], dtype=float)
+        self.dim = len(self.lower_bounds)
+
+        self.costs: list[float] = []
+        self.best_costs: list[float] = []
+        self.global_best_pos: Optional[np.ndarray] = None
+        self.global_best_cost = np.inf
+
+    # ------------------------------------------------------------------
+    # Utility methods
+    # ------------------------------------------------------------------
+    def decode_particle(self, vec: np.ndarray) -> Dict[str, tuple]:
+        """Convert a particle vector into a PID gain dictionary."""
+        return {
+            "k_pid_pos": (vec[0], vec[1], vec[2]),
+            "k_pid_alt": (vec[3], vec[4], vec[5]),
+            "k_pid_att": (vec[6], vec[7], vec[8]),
+            "k_pid_yaw": (0.5, 1e-6, 0.1),
+            "k_pid_hsp": (vec[9], vec[10], vec[11]),
+            "k_pid_vsp": (vec[12], vec[13], vec[14]),
+        }
+
+    def simulate_pid(self, pid_gains: Dict[str, tuple]) -> Dict[str, float]:
+        """Run a simulation with the given PID gains and return the cost metrics."""
+        return run_simulation(
+            pid_gains,
+            self.parameters,
+            self.waypoints,
+            self.world,
+            self.thrust_max,
+            self.simulation_time,
+            noise_model=self.noise_model,
+            simulate_wind=self.simulate_wind_flag,
+        )
+
+    # ------------------------------------------------------------------
+    # Optimization routine
+    # ------------------------------------------------------------------
+    def optimize(self) -> None:
+        """Execute the Particle Swarm Optimization process."""
+        rng = np.random.default_rng(42)
+        particles_pos = rng.uniform(
+            self.lower_bounds, self.upper_bounds, size=(self.swarm_size, self.dim)
+        )
+        particles_vel = np.zeros((self.swarm_size, self.dim))
+
+        if self.set_initial_obs:
+            current_best = mainfunc.load_pid_gains(self.parameters)
+            init_particle = np.array(
+                [
+                    current_best["k_pid_pos"][0],
+                    current_best["k_pid_pos"][1],
+                    current_best["k_pid_pos"][2],
+                    current_best["k_pid_alt"][0],
+                    current_best["k_pid_alt"][1],
+                    current_best["k_pid_alt"][2],
+                    current_best["k_pid_att"][0],
+                    current_best["k_pid_att"][1],
+                    current_best["k_pid_att"][2],
+                    current_best["k_pid_hsp"][0],
+                    current_best["k_pid_hsp"][1],
+                    current_best["k_pid_hsp"][2],
+                    current_best["k_pid_vsp"][0],
+                    current_best["k_pid_vsp"][1],
+                    current_best["k_pid_vsp"][2],
+                ]
+            )
+            particles_pos[0] = np.clip(init_particle, self.lower_bounds, self.upper_bounds)
+
+        personal_best_pos = particles_pos.copy()
+        personal_best_cost = np.full(self.swarm_size, np.inf)
+
+        start_opt = time()
+        print("Starting Particle Swarm Optimization...")
+        try:
+            for gen in range(self.n_iter):
+                for i in range(self.swarm_size):
+                    gains = self.decode_particle(particles_pos[i])
+                    costs_sim = self.simulate_pid(gains)
+                    total_cost = costs_sim["total_cost"]
+                    self.costs.append(total_cost)
+                    log_step(gains, total_cost, self.log_path, costs_sim)
+                    if total_cost < personal_best_cost[i]:
+                        personal_best_cost[i] = total_cost
+                        personal_best_pos[i] = particles_pos[i].copy()
+                    if total_cost < self.global_best_cost:
+                        self.global_best_cost = total_cost
+                        self.global_best_pos = particles_pos[i].copy()
+                for i in range(self.swarm_size):
+                    r1 = rng.random(self.dim)
+                    r2 = rng.random(self.dim)
+                    particles_vel[i] = (
+                        self.w * particles_vel[i]
+                        + self.c1 * r1 * (personal_best_pos[i] - particles_pos[i])
+                        + self.c2 * r2 * (self.global_best_pos - particles_pos[i])
+                    )
+                    particles_pos[i] = particles_pos[i] + particles_vel[i]
+                    particles_pos[i] = np.clip(
+                        particles_pos[i], self.lower_bounds, self.upper_bounds
+                    )
+                self.best_costs.append(self.global_best_cost)
+                if self.verbose:
+                    print(
+                        f"[ PSO ] Generation {gen + 1}/{self.n_iter} | best_cost={self.global_best_cost:.4f}"
+                    )
+        except KeyboardInterrupt:
+            print("Optimization interrupted by user.")
+        finally:
+            tot_time = time() - start_opt
+            if self.global_best_pos is None:
+                print("No evaluations were performed.")
+                return
+            best_params = self.decode_particle(self.global_best_pos)
+            show_best_params(
+                best_params,
+                self.opt_output_path,
+                self.global_best_cost,
+                self.n_iter,
+                self.simulation_time,
+                tot_time,
+            )
+            plot_costs_trend(
+                self.costs,
+                save_path=self.opt_output_path.replace(".txt", "_costs.png"),
+            )
+            plot_costs_trend(
+                self.best_costs,
+                save_path=self.opt_output_path.replace(".txt", "_best_costs.png"),
+            )
 
 
-def simulate_pid(pid_gains, parameters, waypoints, world, thrust_max, simulation_time):
-    """Run a simulation with the given PID gains and return the cost metrics."""
-    init_state = mainfunc.create_initial_state()
-    quad_controller = mainfunc.create_quadcopter_controller(init_state=init_state,
-                                                            pid_gains=pid_gains,
-                                                            t_max=thrust_max,
-                                                            parameters=parameters)
-    
-    drone = mainfunc.create_quadcopter_model(init_state=init_state,
-                                             quad_controller=quad_controller,
-                                             parameters=parameters)
-    
-    sim = mainfunc.create_simulation(drone=drone,
-                                     world=world,
-                                     waypoints=waypoints,
-                                     parameters=parameters,
-                                     noise_model=None)
-    sim.startSimulation(stop_at_target=True, verbose=False, stop_sim_if_not_moving=True, use_static_target=True)
-    return calculate_costs(sim, simulation_time)
-
-
-# initialize logging timers in opt_func
-opt_func.start_time = time()
-opt_func.last_time = opt_func.start_time
-
-def decode_particle(vec: np.ndarray) -> dict:
-    """Convert a particle vector into a PID gain dictionary."""
-    return {
-        'k_pid_pos': (vec[0], vec[1], vec[2]),
-        'k_pid_alt': (vec[3], vec[4], vec[5]),
-        'k_pid_att': (vec[6], vec[7], vec[8]),
-        'k_pid_yaw': (0.5, 1e-6, 0.1),
-        'k_pid_hsp': (vec[9], vec[10], vec[11]),
-        'k_pid_vsp': (vec[12], vec[13], vec[14])
-    }
-
-def main():
+def main() -> None:
     """Run PID optimization using Particle Swarm Optimization."""
-    # Load settings
-    with open(os.path.join('Settings', 'pso_opt.yaml'), 'r') as f:
-        pso_cfg = yaml.safe_load(f)
-    parameters = mainfunc.load_parameters('Settings/simulation_parameters.yaml')
-
-    n_iter = int(pso_cfg.get('n_iter', 100))
-    swarm_size = int(pso_cfg.get('swarm_size', 30))
-    w = float(pso_cfg.get('inertia_weight', 0.7))
-    c1 = float(pso_cfg.get('cognitive_coeff', 1.5))
-    c2 = float(pso_cfg.get('social_coeff', 1.5))
-    simulation_time = float(pso_cfg.get('simulation_time', 150))
-
-    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-    base_dir = os.path.join('Optimizations', 'PSO', timestamp)
-    os.makedirs(base_dir, exist_ok=True)
-    opt_output_path = os.path.join(base_dir, 'best_parameters.txt')
-    log_path = os.path.join(base_dir, 'optimization_log.json')
-
-    thrust_max = mainfunc.get_max_thrust_from_rotor_model(parameters)
-    waypoints = mainfunc.create_training_waypoints()
-    world = World.load_world(parameters['world_data_path'])
-
-    # Parameter bounds loaded from configuration
-    pbounds_cfg = pso_cfg.get('pbounds', {})
-    pbounds = {k: tuple(v) for k, v in pbounds_cfg.items()}
-
-    lower_bounds = np.array([v[0] for v in pbounds.values()], dtype=float)
-    upper_bounds = np.array([v[1] for v in pbounds.values()], dtype=float)
-    dim = len(lower_bounds)
-
-    rng = np.random.default_rng(42)
-    particles_pos = rng.uniform(lower_bounds, upper_bounds, size=(swarm_size, dim))
-    particles_vel = np.zeros((swarm_size, dim))
-
-    # Use current PID gains as one of the particles
-    current_best = mainfunc.load_pid_gains(parameters)
-    init_particle = np.array([
-        current_best['k_pid_pos'][0], current_best['k_pid_pos'][1], current_best['k_pid_pos'][2],
-        current_best['k_pid_alt'][0], current_best['k_pid_alt'][1], current_best['k_pid_alt'][2],
-        current_best['k_pid_att'][0], current_best['k_pid_att'][1], current_best['k_pid_att'][2],
-        current_best['k_pid_hsp'][0], current_best['k_pid_hsp'][1], current_best['k_pid_hsp'][2],
-        current_best['k_pid_vsp'][0], current_best['k_pid_vsp'][1], current_best['k_pid_vsp'][2]
-    ])
-    particles_pos[0] = np.clip(init_particle, lower_bounds, upper_bounds)
-
-    personal_best_pos = particles_pos.copy()
-    personal_best_cost = np.full(swarm_size, np.inf)
-    global_best_pos = None
-    global_best_cost = np.inf
-
-    start_opt = time()
-    print("Starting Particle Swarm Optimization...")
-
-    try:
-        # Main optimization loop
-        for gen in range(n_iter):
-            for i in range(swarm_size):
-                gains = decode_particle(particles_pos[i])
-                costs_sim = simulate_pid(gains, parameters, waypoints, world, thrust_max, simulation_time)
-                total_cost = costs_sim['total_cost']
-                costs.append(total_cost)
-                log_step(gains, total_cost, log_path, costs_sim)
-                if total_cost < personal_best_cost[i]:
-                    personal_best_cost[i] = total_cost
-                    personal_best_pos[i] = particles_pos[i].copy()
-                if total_cost < global_best_cost:
-                    global_best_cost = total_cost
-                    global_best_pos = particles_pos[i].copy()
-            # Update velocity and position
-            for i in range(swarm_size):
-                r1 = rng.random(dim)
-                r2 = rng.random(dim)
-                particles_vel[i] = (w * particles_vel[i] +
-                                    c1 * r1 * (personal_best_pos[i] - particles_pos[i]) +
-                                    c2 * r2 * (global_best_pos - particles_pos[i]))
-                particles_pos[i] = particles_pos[i] + particles_vel[i]
-                particles_pos[i] = np.clip(particles_pos[i], lower_bounds, upper_bounds)
-            best_costs.append(global_best_cost)
-            print(f"[ PSO ] Generation {gen+1}/{n_iter} | best_cost={global_best_cost:.4f}")
-    except KeyboardInterrupt:
-        print("Optimization interrupted by user.")
-    finally:
-        tot_time = time() - start_opt
-        best_params = decode_particle(global_best_pos)
-
-        show_best_params(best_params, opt_output_path, global_best_cost, n_iter, simulation_time, tot_time)
-
-        plot_costs_trend(costs, save_path=opt_output_path.replace(".txt", "_costs.png"))
-        plot_costs_trend(best_costs, save_path=opt_output_path.replace(".txt", "_best_costs.png"))
+    optimizer = PSOPIDOptimizer()
+    optimizer.optimize()
 
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- encapsulate TD3, PSO, and Bayesian PID tuning into reusable optimizer classes
- add shared `run_simulation` helper for running simulations with optional wind
- fix TD3 step logging and expose common configuration options

## Testing
- `python -m py_compile Advanced-Drone-Controller-Optimization/opt_func.py Advanced-Drone-Controller-Optimization/pid_optimization_RL.py Advanced-Drone-Controller-Optimization/pid_optimization_pso.py Advanced-Drone-Controller-Optimization/pid_optimization_bayopt.py`


------
https://chatgpt.com/codex/tasks/task_e_689326d52240832b911c28f1639b8c27