### PR TITLE
Refine noise models and cost computation

### DIFF
--- a/Noise/DNNModel.py
+++ b/Noise/DNNModel.py
@@ -1,56 +1,33 @@
 import numpy as np
 
-class RotorSoundModel():
-    def __init__(self, rpm_reference = 2500, filename = "angles_swl.npy"):
-        """
-        Initialize the noise model by loading the noise model data from a npy file.
-        """
+
+class RotorSoundModel:
+    def __init__(self, rpm_reference: float = 2500, rpm_exponent: float = 5.0,
+                 filename: str = "angles_swl.npy"):
+        """Load pre-computed SWL data and store reference parameters."""
         self.noise_data = np.load(filename, allow_pickle=True)
         self.rpm_reference = rpm_reference
+        self.rpm_exponent = rpm_exponent
 
     def get_noise_emissions(self, zeta_angle, rpms, distance) -> tuple:
-        """
-        Get the Sound Pressure Level (SPL) based on the zeta angle and RPM.
-        The zeta angle is in radians, and the RPM is the rotor speed.
+        """Return SPL and SWL for a given emission angle, RPMs and distance."""
+        zeta_index = min(int(zeta_angle * 180 / np.pi), len(self.noise_data) - 1)
+        # Reference SWL for one rotor (remove contribution of the other three)
+        swl_ref_rpm = self.noise_data[zeta_index] - 6.02
 
-        Parameters:
-            zeta_angle (float): The angle in radians between 0 and 2π calculated as arctan(height/distance).
-            rpms (list): List of RPM values for the rotors.
-            distance (float): The distance from the noise source in meters.
-        Returns:
-            tuple: (SPL, SWL) where SPL is the Sound Pressure Level and SWL is the Sound Power Level.
-        """
-        # Convert radians to degrees and ensure index is within bounds
-        zeta_index = min(int(zeta_angle * 180 / np.pi), len(self.noise_data) - 1) 
-        # Sound Power Level reference for the given zeta angle of a single rotor
-        swl_ref_rpm = self.noise_data[zeta_index] - 6.02 # 6.02 dB: Remove contribution of the other three rotors to get the reference SWL for one rotor
+        swl = self.total_swl_contribution(
+            swl_ref_rpm, rpms, self.rpm_reference, self.rpm_exponent
+        )
+        # Free-field spherical spreading
+        spl = swl - 10 * np.log10(4 * np.pi * (distance + 1e-4) ** 2)
+        return spl, swl
 
-        swl = self.total_swl_contribution(swl_ref_rpm, rpms, self.rpm_reference)
-        # Sound Pressure Level adjusted for distance
-        spl = swl - abs(10 * np.log10(1/(4 * np.pi * ((distance+1e-4)**2)))) 
-        return abs(spl), abs(swl)
-    
     @staticmethod
-    def total_swl_contribution(swl_ref_rpm, rpms, rpm_reference):
-        """
-        Calculate the total Sound Power Level (SWL) contribution from multiple rotors.
-        This function takes the reference SWL for a single rotor at a specific RPM and calculates the
-        total SWL for the given RPMs of all rotors.
-
-        Parameters:
-            swl_ref_rpm (float): The reference Sound Power Level for a single rotor at the reference RPM.
-            rpms (list): List of RPM values for the rotors.
-            rpm_reference (float): The reference RPM value for the noise model.
-        
-        Returns:
-            float: The total Sound Power Level (SWL) in dB.
-        """
-        # Calculate SWL for each rotor
-        swl_individual = swl_ref_rpm + 10 * np.log10((np.array(rpms) + 1) / rpm_reference)
-
-        # Convert to linear scale
+    def total_swl_contribution(swl_ref_rpm, rpms, rpm_reference, rpm_exponent):
+        """Combine SWL contributions from multiple rotors."""
+        rpm_ratio = (np.array(rpms) + 1) / rpm_reference
+        swl_individual = swl_ref_rpm + 10 * np.log10(rpm_ratio ** rpm_exponent)
         powers = 10 ** (swl_individual / 10)
-
-        # Sum contributions and convert back to dB
         swl_total = 10 * np.log10(powers.sum())
         return swl_total
+

--- a/Noise/EmpaModel.py
+++ b/Noise/EmpaModel.py
@@ -8,9 +8,11 @@ def convert_rpm_to_scaled_radians(rpm):
     return (rpm * 2 * np.pi / 60) / 10
 
 def calculate_loudness(SWL):
-    SWL_rms = np.sqrt(np.mean(SWL**2))
-    SWL_loudness_db = 20 * np.log10(SWL_rms)
-    return SWL_loudness_db
+    """Compute loudness by operating in the linear power domain."""
+    swl_lin = 10 ** (SWL / 10)
+    swl_rms = np.sqrt(np.mean(swl_lin ** 2))
+    swl_loudness_db = 10 * np.log10(swl_rms)
+    return swl_loudness_db
 
 lw_ref = np.array([58.06334401, 63.39435536, 89.61406778, 87.6743877 , 88.47605171,
        67.1866716 , 94.21653901, 91.14444512, 81.34365872, 75.15627989,
@@ -165,8 +167,8 @@ class NoiseModel:
 
         predicted_Lw_total = self.predict(input_data)
         swl = calculate_loudness(predicted_Lw_total[0])
-        spl =  swl - abs(10 * np.log10(1/(4 * np.pi * ((distance+1e-4)**2))))
-        return abs(spl), abs(swl)
+        spl = swl - 10 * np.log10(4 * np.pi * (distance + 1e-4) ** 2)
+        return spl, swl
 
 
     def save_model(self, a, b, c, d, filename):


### PR DESCRIPTION
## Summary
- Replace linear RPM scaling with configurable power-law in rotor noise model and express free-field decay without absolutes
- Correct analytical noise model loudness calculation by operating in linear power before converting back to dB
- Base noise cost on SPL L_eq and add psychoacoustic annoyance weighting for optimization

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pybemt')*


------
https://chatgpt.com/codex/tasks/task_e_689493e6f2e4832b9bc9880a6ccd43f0